### PR TITLE
Downgrade image-webpack-loader to avoid error with jpeg files

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "file-loader": "1.1.11",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "3.2.0",
-    "image-webpack-loader": "4.2.0",
+    "image-webpack-loader": "3.6.0",
     "imports-loader": "0.8.0",
     "jest-cli": "22.4.3",
     "lint-staged": "7.0.4",


### PR DESCRIPTION
[https://github.com/tcoopman/image-webpack-loader/issues/142](https://github.com/tcoopman/image-webpack-loader/issues/142)