### PR TITLE
Remove yarn.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,5 @@ stats.json
 npm-debug.log
 .idea
 
-# Lock file
-yarn.lock
-
 # Logs
 yarn-error.log


### PR DESCRIPTION
`yarn.lock` should be tracked. See: https://yarnpkg.com/lang/en/docs/yarn-lock/#toc-check-into-source-control