### PR TITLE
Dispatch action to init reducer state

### DIFF
--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -53,6 +53,7 @@ export default function configureStore(initialState = {}, history) {
   if (module.hot) {
     module.hot.accept('./reducers', () => {
       store.replaceReducer(createReducer(store.injectedReducers));
+      store.dispatch({ type: '@@REDUCER_INJECTED' });
     });
   }
 

--- a/app/utils/reducerInjectors.js
+++ b/app/utils/reducerInjectors.js
@@ -20,6 +20,7 @@ export function injectReducerFactory(store, isValid) {
 
     store.injectedReducers[key] = reducer; // eslint-disable-line no-param-reassign
     store.replaceReducer(createReducer(store.injectedReducers));
+    store.dispatch({ type: '@@REDUCER_INJECTED' });
   };
 }
 

--- a/app/utils/tests/reducerInjectors.test.js
+++ b/app/utils/tests/reducerInjectors.test.js
@@ -60,8 +60,6 @@ describe('reducer injectors', () => {
     });
 
     it('it should not check a store if the second argument is true', () => {
-      Reflect.deleteProperty(store, 'dispatch');
-
       expect(() => injectReducer('test', reducer)).not.toThrow();
     });
 


### PR DESCRIPTION
With this PR reducer `initialState` is properly set even if dynamically injected.
It implements solution proposed by @ruslansavenok in #12

Fixes #12