### PR TITLE
Remove json-loader from base webpack config

### DIFF
--- a/config/webpack.base.babel.js
+++ b/config/webpack.base.babel.js
@@ -71,10 +71,6 @@ module.exports = (options) => ({
         use: 'html-loader'
       },
       {
-        test: /\.json$/,
-        use: 'json-loader'
-      },
-      {
         test: /\.(mp4|webm)$/,
         use: {
           loader: 'url-loader',


### PR DESCRIPTION
With the webpack 4+, you don't need to specify the json-loader in your webpack config. 
Instead, you can simply import the .json files like this
```
import customConfig from "./config.json";
```
Also, please keep in mind that there is no 'json-loader' in the package.json file. 