### PR TITLE
Fixing "Cannot read property cancel of undefined"

### DIFF
--- a/app/utils/sagaInjectors.js
+++ b/app/utils/sagaInjectors.js
@@ -64,7 +64,7 @@ export function ejectSagaFactory(store, isValid) {
 
     if (Reflect.has(store.injectedSagas, key)) {
       const descriptor = store.injectedSagas[key];
-      if (descriptor.mode !== DAEMON) {
+      if (descriptor.mode && descriptor.mode !== DAEMON) {
         descriptor.task.cancel();
         // Clean up in production; in development we need `descriptor.saga` for hot reloading
         if (process.env.NODE_ENV === 'production') {

--- a/app/utils/tests/sagaInjectors.test.js
+++ b/app/utils/tests/sagaInjectors.test.js
@@ -70,9 +70,9 @@ describe('injectors', () => {
       expect(() => ejectSaga(1)).toThrow();
     });
 
-    it('should cancel a saga in a default mode', () => {
+    it('should cancel a saga in RESTART_ON_REMOUNT mode', () => {
       const cancel = jest.fn();
-      store.injectedSagas.test = { task: { cancel } };
+      store.injectedSagas.test = { task: { cancel }, mode: RESTART_ON_REMOUNT };
       ejectSaga('test');
 
       expect(cancel).toHaveBeenCalled();


### PR DESCRIPTION
There actually is a really random bug which trigger sometimes, only in production.

ref: https://github.com/react-boilerplate/react-boilerplate/issues/2021